### PR TITLE
fix: "endpoint" property for S3 not working

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ module.exports = {
         secretAccessKey: config.secretAccessKey,
       },
       region: config.region,
+      ...config,
     });
     return {
       async upload(file, customParams = {}) {


### PR DESCRIPTION
This PR fixed issue #3. In this way, `endpoint` and future configs will be passed to the plugin. I also had to add `https://` to my `endpoint` to work properly, just for future reference.

Thank you for the amazing work and have an amazing year 🎆 