### PR TITLE
added support for uploading  stream instead of buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,37 +16,43 @@ module.exports = {
       region: config.region,
       ...config,
     });
-    return {
-      async upload(file, customParams = {}) {
-        let prefix = config.prefix || "";
-        prefix = prefix.trim() === "/" ? "" : prefix.trim(); // prefix only if not root
-        const path = file.path ? `${file.path}/` : "";
-        const objectPath = `${prefix}${path}${file.hash}${file.ext}`;
-        const uploadParams = {
-          Bucket: config.params.bucket,
-          Key: objectPath,
-          Body: Buffer.from(file.buffer, "binary"),
-          // TODO(fix): this currently breaks uploads
-          // ACL: 'public-read',
-          ContentType: file.mime,
-          ...customParams,
-        };
-        try {
-          // upload file on S3 bucket
-          await S3.send(new PutObjectCommand(uploadParams));
-          // set the bucket file url
-          if (config.baseUrl) {
-            file.url = `${config.baseUrl}/${objectPath}`;
-          } else {
-            // if no baseUrl provided, use the endpoint returned from S3
-            const ep = await S3.config.endpoint();
-            file.url = `https://${config.params.bucket}.${ep.hostname}/${objectPath}`;
-          }
-        } catch (err) {
-          console.error("error uploading object to s3", objectPath);
-          console.error(err);
-          throw err;
+    const upload = async (file, customParams = {}) => {
+      let prefix = config.prefix || "";
+      prefix = prefix.trim() === "/" ? "" : prefix.trim(); // prefix only if not root
+      const path = file.path ? `${file.path}/` : "";
+      const objectPath = `${prefix}${path}${file.hash}${file.ext}`;
+      const uploadParams = {
+        Bucket: config.params.bucket,
+        Key: objectPath,
+        Body: file.stream || Buffer.from(file.buffer, "binary"),
+        // TODO(fix): this currently breaks uploads
+        // ACL: 'public-read',
+        ContentType: file.mime,
+        ...customParams,
+      };
+      try {
+        // upload file on S3 bucket
+        await S3.send(new PutObjectCommand(uploadParams));
+        // set the bucket file url
+        if (config.baseUrl) {
+          file.url = `${config.baseUrl}/${objectPath}`;
+        } else {
+          // if no baseUrl provided, use the endpoint returned from S3
+          const ep = await S3.config.endpoint();
+          file.url = `https://${config.params.bucket}.${ep.hostname}/${objectPath}`;
         }
+      } catch (err) {
+        console.error("error uploading object to s3", objectPath);
+        console.error(err);
+        throw err;
+      }
+    }
+    return {
+      uploadStream(file, customParams = {}) {
+        return upload(file, customParams);
+      },
+      upload(file, customParams = {}) {
+        return upload(file, customParams);
       },
       // delete file in S3 bucket
       async delete(file, customParams = {}) {


### PR DESCRIPTION
Hi,

Strapi v4.1.1 added support for uploading files using `Stream` instead of `Buffer`. This fixes a longstanding [memory leak issue ](https://github.com/strapi/strapi/issues/6432)

I have made the same modifications that have been made to the original S3 provider in Strapi. [(Link to commit)](https://github.com/strapi/strapi/commit/1b4805044033343dfa5bfe10048d8af2d7b4577f)