### PR TITLE
fix: cannot set baseurl to an empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ module.exports = ({ env }) => [
 
 ## Migration
 
+### v4.1.0
+
+To allow for an empty `baseUrl` (#9), we made some adjustments to the way the configuration is parsed: in your `plugins.js`, `env("CDN_BASE_URL")` uses strapi's helper function for parsing ENV variables. If any second argument is omitted,
+`undefined` is returned. Thus, if your ENV does not contain any value for `CDN_BASE_URL`, you are good to go. Undefined `baseUrl` causes the plugin to prepend the cannonic default endpoint of your storage provider, e.g., `https://mystoragebucket.s3.amazonaws.com`.
+
+**If instead you defined `CDN_BASE_URL` to be `""`, the `env` helper returns that empty string.** Previously, this was treated as the same case as using `undefined`. In some scenarios however you might not want this, e.g., local development. **Thus, we now check explicitly for undefinedness instead of the prior truthiness.**. If you defined `CDN_BASE_URL` to be an empty string and relied upon the prepending of the cannonical default endpoint, change your ENV variable either explicitly to the endpoint's URL **or** make it undefined.
+
 ### v3.x to v4.0.x
 
 Strapi now uses the full package name as provider name, as seen in the configuration of the provider in the Example section above. This means that the relation will include different provider names when using the newer version of this provider with strapi >= 4.0.0 on data from pre-4.0.0. In particular, you will find that the pre-4.0.0 `files` will have the provider `aws-s3-advanved`, while the newer ones will have `strapi-provider-aws-s3-advanved`. **If you're not going to change the existing files in your CDN, you will not need to take any actions**. The provider attribute is only used for mapping the handler for creating or deleting files to the handlers defined in _this_ provider. Files will remain readable with the old provider and new files will be added with the new provider name. **Only if you want to delete old files from the new provider, you will be required to adapt the `files` table**.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Your configuration is passed down to the provider. (e.g: `new AWS.S3(config)`). 
 
 See the [using a provider](https://strapi.io/documentation/developer-docs/latest/development/plugins/upload.html#using-a-provider) documentation for information on installing and using a provider. And see the [environment variables](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#environment-variables) for setting and using environment variables in your configs.
 
+To upload with ACLs, **make sure that the S3 user has abilities "s3:PutObjectACL" in addition to the regular "s3:PutObject" ability**. Otherwise S3 will reject the upload with "Access Denied".
+
 ### Example
 
 `./config/plugins.js`
@@ -24,10 +26,11 @@ module.exports = ({ env }) => ({
       secretAccessKey: env("AWS_ACCESS_SECRET"),
       region: env("AWS_REGION"),
       params: {
-        bucket: env("AWS_BUCKET"),
+        bucket: env("AWS_BUCKET"), // or "Bucket", @aws-sdk requires capitalized properties, but the convention for this file is lowercased, but the plugin understands both
+        acl: env("AWS_BUCKET_ACL"), // or "ACL", see above
       },
-      baseUrl: env("CDN_BASE_URL"), // e.g. https://cdn.example.com, this is stored in strapi's database to point to the file
-      prefix: env("BUCKET_PREFIX"), // e.g. strapi-assets, note the missing slash at the start
+      baseUrl: env("CDN_BASE_URL"), // e.g. "https://cdn.example.com", this is stored in strapi's database to point to the file
+      prefix: env("BUCKET_PREFIX"), // e.g. "strapi-assets". If BUCKET_PREFIX contains leading or trailing slashes, they are removed internally to construct the URL safely
     },
   },
   // ...
@@ -49,16 +52,20 @@ module.exports = ({ env }) => ({
         secretAccessKey: env("AWS_ACCESS_SECRET"),
         region: env("AWS_REGION"),
         params: {
-          bucket: env("AWS_BUCKET"),
+          bucket: env("AWS_BUCKET"), // or "Bucket", @aws-sdk requires capitalized properties, but the convention for this file is lowercased, but the plugin understands both
+          acl: env("AWS_BUCKET_ACL"), // or "ACL", see above
         },
-        baseUrl: env("CDN_BASE_URL"), // e.g. https://cdn.example.com, this is stored in strapi's database to point to the file
-        prefix: env("BUCKET_PREFIX"), // e.g. strapi-assets, note the missing slash at the start
+        baseUrl: env("CDN_BASE_URL"), // e.g. "https://cdn.example.com", this is stored in strapi's database to point to the file
+        prefix: env("BUCKET_PREFIX"), // e.g. "strapi-assets". If BUCKET_PREFIX contains leading or trailing slashes, they are removed internally to construct the URL safely
       },
     },
   },
   // ...
 });
 ```
+
+If you need to extend the configuration of the S3 client with additional properties, put them into `providerOptions.params`. The `params` object is spread into the S3 configuration at initialization, so it will accept any
+additional configuration this way.
 
 > Note: If you are migrating from a pre-4.0.0 version (i.e. v3.6.8 or earlier), the `files` relation will include `aws-s3-advanced` as the provider. Previously, the prefix "strapi-upload-provider" was assumed to
 > always be present for upload provider plugins. _This is no longer the case in >= 4.0.0_, hence when uploading with the newer version of this provider, strapi will insert new files with the full provider package name, i.e., `strapi-provider-upload-aws-s3-advanced`. See [Migration](#migration) for details on the required manual work.

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ module.exports = {
 
     const prefix = config.prefix ? normalizePrefix(config.prefix) : "";
     const bucket = config.params.Bucket || config.params.bucket;
-    const acl = config.params.ACL || config.params.acl || "public-read";
+    const acl = config.params.ACL || config.params.acl;
 
     const upload = async (file, customParams = {}) => {
       const path = file.path ? `${file.path}/` : ""; // with trailing slash if present, otherwise empty
@@ -90,8 +90,8 @@ module.exports = {
         Bucket: bucket,
         Key: objectPath,
         Body: file.stream || Buffer.from(file.buffer, "binary"),
-        ACL: acl,
         ContentType: file.mime,
+        ACL: acl,
         ...customParams,
       };
       try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,50 @@
 "use strict";
+//@ts-check
 
 const {
   S3Client,
   PutObjectCommand,
   DeleteObjectCommand,
 } = require("@aws-sdk/client-s3");
+
+/**
+ * removes leading or trailing slashes for url composition in upload or delete functions
+ * @param {string} prefix prefix for object keys defined by configuration
+ * @returns prefix with removed leading or trailing
+ */
+function normalizePrefix(prefix) {
+  return prefix.trim().replace(/^\/*/, "").replace(/\/*$/, "");
+}
+
+/**
+ * Composes an FQDN of the given object path with the bucket's Endpoint
+ * @param {import("@aws-sdk/types").Endpoint} ep
+ * @param {string} bucket
+ * @param {string} path
+ * @returns composed url with bucket endpoint as string
+ */
+function composeBucketUrl(ep, bucket, path) {
+  return (
+    ep.protocol +
+    "://" +
+    bucket +
+    "." +
+    ep.hostname +
+    (ep.port ? ":" + ep.port : "") +
+    "/" +
+    path
+  );
+}
+
+/**
+ * composes a (normalized) URL for CDN usage
+ * @param {string} url CDN base url
+ * @param {string} path object path in CDN
+ * @returns CDN url
+ */
+function composeCDNUrl(url, path) {
+  return (url.endsWith("/") ? url : url + "/") + path;
+}
 
 module.exports = {
   init(config) {
@@ -16,17 +56,20 @@ module.exports = {
       region: config.region,
       ...config,
     });
+
+    const prefix = config.prefix ? normalizePrefix(config.prefix) : "";
+    const bucket = config.params.Bucket || config.params.bucket;
+    const acl = config.params.ACL || config.params.acl || "public-read";
+
     const upload = async (file, customParams = {}) => {
-      let prefix = config.prefix || "";
-      prefix = prefix.trim() === "/" ? "" : prefix.trim(); // prefix only if not root
-      const path = file.path ? `${file.path}/` : "";
-      const objectPath = `${prefix}${path}${file.hash}${file.ext}`;
+      const path = file.path ? `${file.path}` : ""; // with trailing slash if present, otherwise empty
+      const filename = `${file.hash}${file.ext}`; // no leading slash
+      const objectPath = "/" + prefix + "/" + path + "/" + filename;
       const uploadParams = {
-        Bucket: config.params.bucket,
+        Bucket: bucket,
         Key: objectPath,
         Body: file.stream || Buffer.from(file.buffer, "binary"),
-        // TODO(fix): this currently breaks uploads
-        // ACL: 'public-read',
+        ACL: acl,
         ContentType: file.mime,
         ...customParams,
       };
@@ -37,16 +80,17 @@ module.exports = {
         if (config.baseUrl === undefined) {
           // if no baseUrl provided, use the endpoint returned from S3
           const ep = await S3.config.endpoint();
-          file.url = `https://${config.params.bucket}.${ep.hostname}/${objectPath}`;
+          file.url = composeBucketUrl(ep, bucket, objectPath);
         } else {
-          file.url = `${config.baseUrl}/${objectPath}`;
+          const baseUrl = config.baseUrl ? `${config.baseUrl}` : "";
+          file.url = composeCDNUrl(baseUrl, objectPath);
         }
       } catch (err) {
-        console.error("error uploading object to s3", objectPath);
+        console.error("Error uploading object to bucket", objectPath);
         console.error(err);
         throw err;
       }
-    }
+    };
     return {
       uploadStream(file, customParams = {}) {
         return upload(file, customParams);
@@ -56,19 +100,19 @@ module.exports = {
       },
       // delete file in S3 bucket
       async delete(file, customParams = {}) {
-        let prefix = config.prefix || "";
-        prefix = prefix.trim() === "/" ? "" : prefix.trim(); // prefix only if not root
         const path = file.path ? `${file.path}/` : "";
+        const filename = `${file.hash}${file.ext}`;
+        const objectPath = "/" + prefix + "/" + path + "/" + filename;
         try {
           await S3.send(
             new DeleteObjectCommand({
-              Bucket: config.params.bucket,
-              Key: `${prefix}${path}${file.hash}${file.ext}`,
+              Bucket: bucket,
+              Key: objectPath,
               ...customParams,
             })
           );
         } catch (err) {
-          console.error("error deleting object", path);
+          console.error("Error deleting object from bucket", objectPath);
           console.error(err);
           throw err;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,11 @@ const {
  * @returns prefix with removed leading or trailing
  */
 function normalizePrefix(prefix) {
-  return prefix.trim().replace(/^\/*/, "").replace(/\/*$/, "");
+  prefix = prefix.trim().replace(/^\/*/, "").replace(/\/*$/, "");
+  if (!prefix) {
+    return "";
+  }
+  return prefix + "/";
 }
 
 /**
@@ -85,7 +89,7 @@ module.exports = {
     const upload = async (file, customParams = {}) => {
       const path = file.path ? `${file.path}/` : ""; // with trailing slash if present, otherwise empty
       const filename = `${file.hash}${file.ext}`; // no leading slash
-      const objectPath = "/" + prefix + "/" + path + filename;
+      const objectPath = "/" + prefix + path + filename;
       const uploadParams = {
         Bucket: bucket,
         Key: objectPath,
@@ -125,7 +129,7 @@ module.exports = {
       async delete(file, customParams = {}) {
         const path = file.path ? `${file.path}/` : "";
         const filename = `${file.hash}${file.ext}`;
-        const objectPath = "/" + prefix + "/" + path + filename;
+        const objectPath = "/" + prefix + path + filename;
         try {
           await S3.send(
             new DeleteObjectCommand({

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,23 @@ const {
 } = require("@aws-sdk/client-s3");
 
 /**
- * removes leading or trailing slashes for url composition in upload or delete functions
+ * @typedef BucketParams
+ * @property {string|undefined} [Bucket]
+ * @property {string|undefined} [bucket]
+ * @property {string|undefined} [ACL]
+ * @property {string|undefined} [acl]
+ *
+ * @typedef ProviderConfiguration
+ * @property {BucketParams} params
+ * @property {string} accessKeyId
+ * @property {string} secretAccessKey
+ * @property {string} region
+ * @property {string} [prefix]
+ * @property {string} [baseUrl]
+ */
+
+/**
+ * Removes leading or trailing slashes for url composition in upload or delete functions
  * @param {string} prefix prefix for object keys defined by configuration
  * @returns prefix with removed leading or trailing
  */
@@ -47,6 +63,11 @@ function composeCDNUrl(url, path) {
 }
 
 module.exports = {
+  /**
+   * Creates a hoisted S3 client and returns functions for uploading and deleting
+   * @param {ProviderConfiguration} config
+   * @returns object with upload, uploadStream, and delete function
+   */
   init(config) {
     const S3 = new S3Client({
       credentials: {
@@ -91,6 +112,7 @@ module.exports = {
         throw err;
       }
     };
+
     return {
       uploadStream(file, customParams = {}) {
         return upload(file, customParams);

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,10 @@ module.exports = {
 
     const prefix = config.prefix ? normalizePrefix(config.prefix) : "";
     const bucket = config.params.Bucket || config.params.bucket;
-    const acl = config.params.ACL || config.params.acl;
+    const acl =
+      config.params.ACL || config.params.acl
+        ? { ACL: config.params.ACL || config.params.acl }
+        : {};
 
     const upload = async (file, customParams = {}) => {
       const path = file.path ? `${file.path}/` : ""; // with trailing slash if present, otherwise empty
@@ -95,7 +98,7 @@ module.exports = {
         Key: objectPath,
         Body: file.stream || Buffer.from(file.buffer, "binary"),
         ContentType: file.mime,
-        ACL: acl,
+        ...acl,
         ...customParams,
       };
       try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ module.exports = {
     const upload = async (file, customParams = {}) => {
       const path = file.path ? `${file.path}/` : ""; // with trailing slash if present, otherwise empty
       const filename = `${file.hash}${file.ext}`; // no leading slash
-      const objectPath = "/" + prefix + path + filename;
+      const objectPath = prefix + path + filename;
       const uploadParams = {
         Bucket: bucket,
         Key: objectPath,
@@ -111,7 +111,6 @@ module.exports = {
           file.url = composeCDNUrl(baseUrl, objectPath);
         }
       } catch (err) {
-        console.debug(objectPath, bucket, prefix, path, filename);
         console.error("Error uploading object to bucket", objectPath);
         console.error(err);
         throw err;
@@ -129,7 +128,7 @@ module.exports = {
       async delete(file, customParams = {}) {
         const path = file.path ? `${file.path}/` : "";
         const filename = `${file.hash}${file.ext}`;
-        const objectPath = "/" + prefix + path + filename;
+        const objectPath = prefix + path + filename;
         try {
           await S3.send(
             new DeleteObjectCommand({

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,12 +35,12 @@ module.exports = {
           // upload file on S3 bucket
           await S3.send(new PutObjectCommand(uploadParams));
           // set the bucket file url
-          if (config.baseUrl) {
-            file.url = `${config.baseUrl}/${objectPath}`;
-          } else {
+          if (config.baseUrl === undefined) {
             // if no baseUrl provided, use the endpoint returned from S3
             const ep = await S3.config.endpoint();
             file.url = `https://${config.params.bucket}.${ep.hostname}/${objectPath}`;
+          } else {
+            file.url = `${config.baseUrl}/${objectPath}`;
           }
         } catch (err) {
           console.error("error uploading object to s3", objectPath);

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,9 +83,9 @@ module.exports = {
     const acl = config.params.ACL || config.params.acl || "public-read";
 
     const upload = async (file, customParams = {}) => {
-      const path = file.path ? `${file.path}` : ""; // with trailing slash if present, otherwise empty
+      const path = file.path ? `${file.path}/` : ""; // with trailing slash if present, otherwise empty
       const filename = `${file.hash}${file.ext}`; // no leading slash
-      const objectPath = "/" + prefix + "/" + path + "/" + filename;
+      const objectPath = "/" + prefix + "/" + path + filename;
       const uploadParams = {
         Bucket: bucket,
         Key: objectPath,
@@ -107,6 +107,7 @@ module.exports = {
           file.url = composeCDNUrl(baseUrl, objectPath);
         }
       } catch (err) {
+        console.debug(objectPath, bucket, prefix, path, filename);
         console.error("Error uploading object to bucket", objectPath);
         console.error(err);
         throw err;
@@ -124,7 +125,7 @@ module.exports = {
       async delete(file, customParams = {}) {
         const path = file.path ? `${file.path}/` : "";
         const filename = `${file.hash}${file.ext}`;
-        const objectPath = "/" + prefix + "/" + path + "/" + filename;
+        const objectPath = "/" + prefix + "/" + path + filename;
         try {
           await S3.send(
             new DeleteObjectCommand({

--- a/package.json
+++ b/package.json
@@ -20,15 +20,13 @@
     "isProvider": true
   },
   "author": {
-    "email": "alexander.bartolomey@anny.co",
-    "name": "Alexander Bartolomey",
-    "url": "https://anny.co"
+    "email": "occloxium@gmail.com",
+    "name": "Alexander Bartolomey"
   },
   "maintainers": [
     {
       "name": "Alexander Bartolomey",
-      "email": "alexander.bartolomey@anny.co",
-      "url": "https://anny.co"
+      "email": "occloxium@gmail.com"
     }
   ],
   "repository": {


### PR DESCRIPTION
Flips the checking of baseUrl definedness to check for explicit undefinedness