### PR TITLE
handle no credentials config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,16 @@ const {
 
 module.exports = {
   init(config) {
-    const S3 = new S3Client({
+    const credentials = config.accessKeyId && config.secretAccessKey ?
+    {
       credentials: {
         accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey,
-      },
+        secretAccessKey: config.secretAccessKey
+      }
+    } : {};
+    const S3 = new S3Client({
       region: config.region,
+      ...credentials,
       ...config,
     });
     const upload = async (file, customParams = {}) => {


### PR DESCRIPTION
allows the plugin to work when an ECS task role is handling permission instead of exposing a key and secret.