### PR TITLE
Fix saved media url starting with https:://

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function normalizePrefix(prefix) {
 function composeBucketUrl(ep, bucket, path) {
   return (
     ep.protocol +
-    "://" +
+    (ep.protocol.endsWith(':') ? "//" : "://") +
     bucket +
     "." +
     ep.hostname +


### PR DESCRIPTION
I noticed that the url of the uploaded media was saved as `https:://bucket.s3.region.amazonaws.com/path/object_key` (i.e.: with double colon after the url schema).
I added a check to see whether it's necessary or not.