### PR TITLE
chore!: update nodejs version constraints

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,8 @@
 "use strict";
 //@ts-check
 
-const {
-  S3Client,
-  PutObjectCommand,
-  DeleteObjectCommand,
-} = require("@aws-sdk/client-s3");
+const { S3Client, DeleteObjectCommand } = require("@aws-sdk/client-s3");
+const { Upload } = require("@aws-sdk/lib-storage");
 
 /**
  * @typedef BucketParams
@@ -46,7 +43,7 @@ function normalizePrefix(prefix) {
 function composeBucketUrl(ep, bucket, path) {
   return (
     ep.protocol +
-    (ep.protocol.endsWith(':') ? "//" : "://") +
+    (ep.protocol.endsWith(":") ? "//" : "://") +
     bucket +
     "." +
     ep.hostname +
@@ -73,13 +70,15 @@ module.exports = {
    * @returns object with upload, uploadStream, and delete function
    */
   init(config) {
-    const credentials = config.accessKeyId && config.secretAccessKey ?
-    {
-      credentials: {
-        accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey
-      }
-    } : {};
+    const credentials =
+      config.accessKeyId && config.secretAccessKey
+        ? {
+            credentials: {
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+            },
+          }
+        : {};
     const S3 = new S3Client({
       region: config.region,
       ...credentials,
@@ -107,7 +106,13 @@ module.exports = {
       };
       try {
         // upload file on S3 bucket
-        await S3.send(new PutObjectCommand(uploadParams));
+
+        const uploadPromise = new Upload({
+          client: S3,
+          params: uploadParams,
+        });
+
+        await uploadPromise.done();
         // set the bucket file url
         if (config.baseUrl === undefined) {
           // if no baseUrl provided, use the endpoint returned from S3

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/zoomoid/strapi-provider-upload-aws-s3-advanced/issues"
   },
   "engines": {
-    "node": ">=10.16.0 <=16.x.x",
+    "node": ">=14.19.1 <=18.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "main": "./lib",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.43.0"
+    "@aws-sdk/client-s3": "^3.43.0",
+    "@aws-sdk/lib-storage": "^3.100.0"
   },
   "strapi": {
     "isProvider": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-provider-upload-aws-s3-advanced",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "description": "AWS S3 provider for strapi upload with more advanced configuration options",
   "homepage": "https://strapi.io",
   "keywords": [


### PR DESCRIPTION
⚠️ As Node 10 and Node 12 are EOL now, this PR drops further support for those versions. The only supported NodeJS versions 
are v14 and upwards, which aligns with strapi's constraints.

Aligns the provider's nodejs/npm constraints with those of the aws-s3 provider of strapi itself.

Closes #19 
